### PR TITLE
substitute outline placeholders in arguments

### DIFF
--- a/plugins/gherkin-openbbt-plugin/src/main/java/org/myjtools/openbbt/plugins/gherkin/FeaturePlanAssembler.java
+++ b/plugins/gherkin-openbbt-plugin/src/main/java/org/myjtools/openbbt/plugins/gherkin/FeaturePlanAssembler.java
@@ -294,15 +294,35 @@ public class FeaturePlanAssembler {
 			if (scenarioID.isEmpty()) {
 				return scenarioID;
 			}
-			repository.getNodeChildren(scenarioID.orElseThrow()).forEach(scenarioChildID -> {
-				var scenarioChild = repository.getNodeData(scenarioChildID).orElseThrow();
-				if (scenarioChild.name() != null) {
-					scenarioChild.name(substitution.apply(scenarioChild.name()));
-					repository.persistNode(scenarioChild);
-				}
-			});
+			applySubstitution(scenarioID.orElseThrow(), substitution);
 			return scenarioID;
 		}).stream().filter(Optional::isPresent).map(Optional::get).toList();
+	}
+
+
+	private void applySubstitution(UUID nodeID, Function<String,String> substitution) {
+		var node = repository.getNodeData(nodeID).orElseThrow();
+		if (node.name() != null) {
+			node.name(substitution.apply(node.name()));
+		}
+		if (node.description() != null) {
+			node.description(substitution.apply(node.description()));
+		}
+		if (node.document() != null) {
+			node.document(new Document(
+				node.document().mimeType(),
+				substitution.apply(node.document().content())
+			));
+		}
+		if (node.dataTable() != null) {
+			node.dataTable(new org.myjtools.openbbt.core.testplan.DataTable(
+				node.dataTable().values().stream()
+					.map(row -> row.stream().map(substitution).toList())
+					.toList()
+			));
+		}
+		repository.persistNode(node);
+		repository.getNodeChildren(nodeID).forEach(childID -> applySubstitution(childID, substitution));
 	}
 
 

--- a/plugins/gherkin-openbbt-plugin/src/test/java/org/myjtools/openbbt/plugins/gherkin/test/GherkinSuiteAssemblerTest.java
+++ b/plugins/gherkin-openbbt-plugin/src/test/java/org/myjtools/openbbt/plugins/gherkin/test/GherkinSuiteAssemblerTest.java
@@ -7,6 +7,7 @@ import org.myjtools.openbbt.core.*;
 import org.myjtools.openbbt.core.persistence.TestPlanRepository;
 import org.myjtools.openbbt.core.persistence.TestPlanRepositoryWriter;
 import org.myjtools.openbbt.core.contributors.SuiteAssembler;
+import org.myjtools.openbbt.core.testplan.NodeType;
 import org.myjtools.openbbt.core.testplan.TagExpression;
 import org.myjtools.openbbt.core.testplan.TestSuite;
 import java.io.IOException;
@@ -161,7 +162,48 @@ class GherkinSuiteAssemblerTest {
 
 	}
 
+	@Test
+	void testScenarioOutlineSubstitutesPlaceholdersInDocStringsAndDataTables() {
+		AssembledSuite suite = assembleSuiteData("src/test/resources/test-outline-arguments");
+		TestPlanRepository repository = suite.repository();
+
+		var nodes = repository.getNodeDescendants(suite.rootNode()).toList().stream()
+			.map(id -> repository.getNodeData(id).orElseThrow())
+			.toList();
+
+		assertThat(nodes)
+			.filteredOn(node -> node.nodeType() == NodeType.STEP && node.document() != null)
+			.extracting(node -> node.document().content())
+			.containsExactly(
+				"{\n  \"name\": \"Alice\",\n  \"age\": 31\n}",
+				"{\n  \"name\": \"Bob\",\n  \"age\": 42\n}"
+			);
+
+		assertThat(nodes)
+			.filteredOn(node -> node.nodeType() == NodeType.STEP && node.dataTable() != null)
+			.extracting(node -> node.dataTable().values())
+			.containsExactly(
+				java.util.List.of(
+					java.util.List.of("name", "age"),
+					java.util.List.of("Alice", "31")
+				),
+				java.util.List.of(
+					java.util.List.of("name", "age"),
+					java.util.List.of("Bob", "42")
+				)
+			);
+	}
+
 	private String assembleSuite(String path) throws IOException {
+		AssembledSuite suite = assembleSuiteData(path);
+		TestPlanRepository repository = suite.repository();
+		TestPlanRepositoryWriter writer = new TestPlanRepositoryWriter(repository);
+		StringBuilder output = new StringBuilder();
+		writer.write(suite.rootNode(), output::append);
+		return output.toString();
+	}
+
+	private AssembledSuite assembleSuiteData(String path) {
 		OpenBBTRuntime cm = new OpenBBTRuntime(Config.ofMap(Map.of(
 			OpenBBTConfig.ENV_PATH, "target/.openbbt",
 			OpenBBTConfig.RESOURCE_PATH, path,
@@ -170,12 +212,11 @@ class GherkinSuiteAssemblerTest {
 		)));
 		var planAssembler = cm.getExtensions(SuiteAssembler.class).findFirst().orElseThrow();
 		TestSuite testSuite = new TestSuite("Test Suite", "Test Suite", TagExpression.EMPTY);
-		UUID planID = planAssembler.assembleSuite(testSuite).orElseThrow();
+		UUID rootNode = planAssembler.assembleSuite(testSuite).orElseThrow();
 		TestPlanRepository repository = cm.getRepository(TestPlanRepository.class);
-		TestPlanRepositoryWriter writer = new TestPlanRepositoryWriter(repository);
-		StringBuilder output = new StringBuilder();
-		writer.write(planID, output::append);
-		return output.toString();
+		return new AssembledSuite(rootNode, repository);
 	}
+
+	private record AssembledSuite(UUID rootNode, TestPlanRepository repository) {}
 
 }

--- a/plugins/gherkin-openbbt-plugin/src/test/resources/test-outline-arguments/outline-arguments.feature
+++ b/plugins/gherkin-openbbt-plugin/src/test/resources/test-outline-arguments/outline-arguments.feature
@@ -1,0 +1,19 @@
+# language: en
+Feature: Scenario outline arguments
+
+Scenario Outline: Substitute arguments outside the step text
+  When I submit this payload:
+    """json
+    {
+      "name": "<name>",
+      "age": <age>
+    }
+    """
+  Then the users table contains:
+    | name   | age   |
+    | <name> | <age> |
+
+Examples:
+  | name  | age |
+  | Alice | 31  |
+  | Bob   | 42  |


### PR DESCRIPTION
## Description

Updates the Gherkin suite assembler so Scenario Outline example placeholders are substituted not only in step text, but also inside step arguments.

## Related issue

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [x] Other: improvement

## Checklist

- [x] My branch is based on `develop`
- [x] Tests added or updated for the changes
- [ ] `./mvnw clean verify` passes locally
- [ ] Documentation updated if needed