### PR TITLE
feat: add HelpProvider SPI and VS Code help pages integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,39 @@ jobs:
       - name: Test all modules
         run: ./mvnw -B verify -Pplugins
 
+      - name: Upload JaCoCo reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-reports
+          path: '**/target/site/jacoco/jacoco.xml'
+          retention-days: 1
+
+  sonar:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build without tests
+        run: ./mvnw -B install -DskipTests -Pplugins
+
+      - name: Download JaCoCo reports
+        uses: actions/download-artifact@v4
+        with:
+          name: jacoco-reports
+
       - name: SonarCloud analysis
-        if: github.actor != 'dependabot[bot]'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./mvnw -B sonar:sonar -Pplugins -Dsonar.projectKey=org-azertio_azertio -Dsonar.organization=org-azertio -Dsonar.host.url=https://sonarcloud.io
+        run: ./mvnw -B sonar:sonar -Pplugins -DskipTests -Dsonar.projectKey=org-azertio_azertio -Dsonar.organization=org-azertio -Dsonar.host.url=https://sonarcloud.io

--- a/azertio-cli/src/main/java/org/azertio/cli/ServeCommand.java
+++ b/azertio-cli/src/main/java/org/azertio/cli/ServeCommand.java
@@ -17,6 +17,7 @@ import picocli.CommandLine;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
 
@@ -87,6 +88,22 @@ public final class ServeCommand extends AbstractCommand {
             }
         };
 
+        JsonRpcServer.HelpRegistryProvider helpRegistryProvider = new JsonRpcServer.HelpRegistryProvider() {
+            @Override
+            public List<JsonRpcServer.HelpRegistryProvider.Entry> list() {
+                return runtime.getExtensions(org.azertio.core.contributors.HelpProvider.class)
+                    .map(p -> new JsonRpcServer.HelpRegistryProvider.Entry(p.id(), p.displayName()))
+                    .toList();
+            }
+            @Override
+            public Optional<String> content(String id) {
+                return runtime.getExtensions(org.azertio.core.contributors.HelpProvider.class)
+                    .filter(p -> p.id().equals(id))
+                    .findFirst()
+                    .map(org.azertio.core.contributors.HelpProvider::help);
+            }
+        };
+
         new JsonRpcServer(System.in, System.out, new JsonRpcServer.RepositoryFactory() {
             @Override public TestPlanRepository open() {
                 return runtime.getRepository(TestPlanRepository.class);
@@ -97,6 +114,6 @@ public final class ServeCommand extends AbstractCommand {
             @Override public AttachmentRepository openAttachment() {
                 return runtime.getRepository(AttachmentRepository.class);
             }
-        }, execHandler, planHandler, runtime::getContributors, runtime::getStepIndex).run();
+        }, execHandler, planHandler, runtime::getContributors, runtime::getStepIndex, helpRegistryProvider).run();
     }
 }

--- a/azertio-core/src/main/java/module-info.java
+++ b/azertio-core/src/main/java/module-info.java
@@ -38,6 +38,7 @@ module org.azertio.core {
 	exports org.azertio.core.datatypes;
 	exports org.azertio.core.assertions;
 	exports org.azertio.core.docgen;
+	exports org.azertio.core.help;
 	exports org.azertio.core.validator;
 	exports org.azertio.core.steps;
 	exports org.azertio.core.contenttypes;
@@ -56,8 +57,10 @@ module org.azertio.core {
 	opens org.azertio.core.execution to org.myjtools.jexten;
 	opens org.azertio.core.validator to org.myjtools.jexten;
 	opens org.azertio.core.steps to org.myjtools.jexten;
+	opens org.azertio.core.help to org.myjtools.jexten;
 
 	uses org.azertio.core.contributors.AIIndexProvider;
+	uses HelpProvider;
 	uses ContentType;
 	uses AssertionFactoryProvider;
 	uses DataTypeProvider;
@@ -84,5 +87,8 @@ module org.azertio.core {
 	provides AssertionFactoryProvider with org.azertio.core.assertions.CoreAssertionFactories;
 	provides TestPlanValidator with DefaultPlanValidator;
 	provides StepProvider with org.azertio.core.steps.CoreStepProvider;
+	provides HelpProvider with
+		org.azertio.core.steps.CoreStepHelpProvider,
+		org.azertio.core.steps.CoreConfigHelpProvider;
 
 }

--- a/azertio-core/src/main/java/org/azertio/core/AzertioPluginManager.java
+++ b/azertio-core/src/main/java/org/azertio/core/AzertioPluginManager.java
@@ -8,6 +8,8 @@ import org.myjtools.jexten.plugin.PluginID;
 import org.myjtools.jexten.plugin.PluginManager;
 import org.myjtools.mavenfetcher.MavenFetcherProperties;
 import org.azertio.core.util.Log;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
 
@@ -28,6 +30,20 @@ public class AzertioPluginManager {
 		);
 		Properties mavenFetcherProperties = computeMavenFetcherProperties(config, envPath);
 		this.pluginManager.setArtifactStore(new MavenArtifactStore().configure(mavenFetcherProperties));
+		logPluginArtifacts(envPath.resolve(AzertioConfig.PLUGINS_PATH));
+	}
+
+	private void logPluginArtifacts(Path pluginsPath) {
+		Path artifactsPath = pluginsPath.resolve("artifacts");
+		if (!Files.isDirectory(artifactsPath)) {
+			return;
+		}
+		try (var stream = Files.walk(artifactsPath)) {
+			stream.filter(p -> p.toString().endsWith(".jar"))
+				.forEach(jar -> log.info("[plugins] artifact: {}", jar.toAbsolutePath()));
+		} catch (IOException e) {
+			log.warn("[plugins] could not list artifacts: {}", e.getMessage());
+		}
 	}
 
 	public ModuleLayerProvider moduleLayerProvider() {

--- a/azertio-core/src/main/java/org/azertio/core/AzertioRuntime.java
+++ b/azertio-core/src/main/java/org/azertio/core/AzertioRuntime.java
@@ -228,7 +228,8 @@ public class AzertioRuntime implements InjectionProvider {
 			ReportBuilder.class,
 			StepProvider.class,
 			SuiteAssembler.class,
-			AIIndexProvider.class
+			AIIndexProvider.class,
+			HelpProvider.class
 		);
 	}
 

--- a/azertio-core/src/main/java/org/azertio/core/contributors/HelpProvider.java
+++ b/azertio-core/src/main/java/org/azertio/core/contributors/HelpProvider.java
@@ -1,0 +1,14 @@
+package org.azertio.core.contributors;
+
+import org.myjtools.jexten.ExtensionPoint;
+
+@ExtensionPoint
+public interface HelpProvider extends Contributor {
+
+    String id();
+
+    String displayName();
+
+    String help();
+
+}

--- a/azertio-core/src/main/java/org/azertio/core/docgen/ConfigDocMarkdownGenerator.java
+++ b/azertio-core/src/main/java/org/azertio/core/docgen/ConfigDocMarkdownGenerator.java
@@ -1,0 +1,54 @@
+package org.azertio.core.docgen;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ConfigDocMarkdownGenerator {
+
+    public String generate(String title, Map<String, ConfigDocEntry> entries) {
+        var sb = new StringBuilder();
+        sb.append("# ").append(title).append("\n\n");
+        for (var entry : entries.entrySet()) {
+            appendEntry(sb, entry.getKey(), entry.getValue());
+        }
+        return sb.toString();
+    }
+
+    private void appendEntry(StringBuilder sb, String key, ConfigDocEntry entry) {
+        sb.append("---\n\n");
+        sb.append("## `").append(key).append("`\n\n");
+
+        if (entry.description() != null && !entry.description().isBlank()) {
+            sb.append(entry.description().stripTrailing()).append("\n\n");
+        }
+
+        sb.append("**Type** ").append(entry.type()).append("\n\n");
+
+        if (entry.required()) {
+            sb.append("**Required**\n\n");
+        }
+        if (entry.defaultValue() != null) {
+            sb.append("**Default value** `").append(entry.defaultValue()).append("`\n\n");
+        }
+        if (entry.constraintPattern() != null) {
+            sb.append("**Pattern** `").append(entry.constraintPattern()).append("`\n\n");
+        }
+        if (entry.constraintMin() != null) {
+            sb.append("**Min** `").append(entry.constraintMin()).append("` ");
+        }
+        if (entry.constraintMax() != null) {
+            sb.append("**Max** `").append(entry.constraintMax()).append("` ");
+        }
+        if (entry.constraintMin() != null || entry.constraintMax() != null) {
+            sb.append("\n\n");
+        }
+        if (entry.constraintValues() != null && !entry.constraintValues().isEmpty()) {
+            String values = entry.constraintValues().stream()
+                .map(v -> "`" + v + "`")
+                .collect(Collectors.joining(", "));
+            sb.append("**Values**  ").append(values).append(" \n\n");
+        }
+
+        sb.append("\n\n");
+    }
+}

--- a/azertio-core/src/main/java/org/azertio/core/docgen/StepDocMarkdownGenerator.java
+++ b/azertio-core/src/main/java/org/azertio/core/docgen/StepDocMarkdownGenerator.java
@@ -1,0 +1,84 @@
+package org.azertio.core.docgen;
+
+import java.util.Map;
+
+public class StepDocMarkdownGenerator {
+
+    public String generate(String title, Map<String, StepDocEntry> steps) {
+        var sb = new StringBuilder();
+        sb.append("# ").append(title).append("\n\n");
+        for (var stepEntry : steps.entrySet()) {
+            appendStep(sb, stepEntry.getKey(), stepEntry.getValue());
+        }
+        return sb.toString();
+    }
+
+    private void appendStep(StringBuilder sb, String id, StepDocEntry entry) {
+        sb.append("---\n\n");
+        sb.append("## `").append(id).append("`\n\n");
+
+        if (entry.role() != null) {
+            sb.append("**Role:** `").append(entry.role()).append("`\n\n");
+        }
+
+        sb.append(entry.description()).append("\n\n");
+
+        if (entry.parameters() != null && !entry.parameters().isEmpty()) {
+            sb.append("### Parameters\n\n");
+            sb.append("| Name | Type | Description |\n");
+            sb.append("|------|------|-------------|\n");
+            for (var param : entry.parameters()) {
+                sb.append("| `").append(param.name()).append("` | ")
+                  .append(param.type()).append(" | ")
+                  .append(param.description()).append(" |\n");
+            }
+            sb.append("\n");
+        }
+
+        if (entry.additionalData() != null) {
+            sb.append("### Additional data\n\n");
+            sb.append(entry.additionalData()).append("\n\n");
+        }
+
+        if (entry.language() != null && !entry.language().isEmpty()) {
+            for (var langEntry : entry.language().entrySet()) {
+                appendLanguageSection(sb, langEntry.getKey(), langEntry.getValue());
+            }
+        }
+    }
+
+    private void appendLanguageSection(StringBuilder sb, String lang, StepLanguageEntry entry) {
+        sb.append("### `").append(lang).append("`\n\n");
+
+        if (entry.expression() != null) {
+            sb.append("**Expression:** `").append(entry.expression()).append("`\n\n");
+        }
+
+        if (entry.assertionHints() != null && !entry.assertionHints().isEmpty()) {
+            sb.append("**Assertion expressions:**\n\n");
+            for (var hint : entry.assertionHints()) {
+                sb.append("- `").append(hint).append("`\n");
+            }
+            sb.append("\n");
+        }
+
+        if (entry.example() != null) {
+            sb.append("**Example:**\n\n");
+            sb.append("```gherkin\n");
+            sb.append(entry.example()).append("\n");
+            sb.append("```\n\n");
+        }
+
+        if (entry.scenarios() != null && !entry.scenarios().isEmpty()) {
+            sb.append("**Scenarios:**\n\n");
+            for (var scenario : entry.scenarios()) {
+                if (scenario.title() != null) {
+                    sb.append("*").append(scenario.title()).append("*\n\n");
+                }
+                sb.append("```gherkin\n");
+                sb.append(scenario.gherkin()).append("\n");
+                sb.append("```\n\n");
+            }
+        }
+    }
+}

--- a/azertio-core/src/main/java/org/azertio/core/help/ConfigHelpAdapter.java
+++ b/azertio-core/src/main/java/org/azertio/core/help/ConfigHelpAdapter.java
@@ -9,26 +9,33 @@ public abstract class ConfigHelpAdapter implements HelpProvider {
 
     private static final Log log = Log.of();
 
-    @Override
-    public String help() {
-        return generateHelp();
+    private final String id;
+    private final String displayName;
+    private final String title;
+    private final String resource;
+
+    protected ConfigHelpAdapter(String id, String displayName, String title, String resource) {
+        this.id = id;
+        this.displayName = displayName;
+        this.title = title;
+        this.resource = resource;
     }
 
-    protected abstract String resource();
+    @Override public String id()          { return id; }
+    @Override public String displayName() { return displayName; }
 
-    protected abstract String title();
-
-    private String generateHelp() {
+    @Override
+    public String help() {
         var mod = getClass().getModule();
-        try (var stream = mod.getResourceAsStream(resource())) {
+        try (var stream = mod.getResourceAsStream(resource)) {
             if (stream == null) {
-                log.warn("[help] resource not found in module {}: {}", mod.getName(), resource());
+                log.warn("[help] resource not found in module {}: {}", mod.getName(), resource);
                 return "";
             }
             var docs = ConfigDocLoader.load(stream);
-            return new ConfigDocMarkdownGenerator().generate(title(), docs);
+            return new ConfigDocMarkdownGenerator().generate(title, docs);
         } catch (Exception e) {
-            log.error(e, "Failed to generate config help for {}", id());
+            log.error(e, "Failed to generate config help for {}", id);
             return "";
         }
     }

--- a/azertio-core/src/main/java/org/azertio/core/help/ConfigHelpAdapter.java
+++ b/azertio-core/src/main/java/org/azertio/core/help/ConfigHelpAdapter.java
@@ -1,0 +1,35 @@
+package org.azertio.core.help;
+
+import org.azertio.core.contributors.HelpProvider;
+import org.azertio.core.docgen.ConfigDocLoader;
+import org.azertio.core.docgen.ConfigDocMarkdownGenerator;
+import org.azertio.core.util.Log;
+
+public abstract class ConfigHelpAdapter implements HelpProvider {
+
+    private static final Log log = Log.of();
+
+    @Override
+    public String help() {
+        return generateHelp();
+    }
+
+    protected abstract String resource();
+
+    protected abstract String title();
+
+    private String generateHelp() {
+        var mod = getClass().getModule();
+        try (var stream = mod.getResourceAsStream(resource())) {
+            if (stream == null) {
+                log.warn("[help] resource not found in module {}: {}", mod.getName(), resource());
+                return "";
+            }
+            var docs = ConfigDocLoader.load(stream);
+            return new ConfigDocMarkdownGenerator().generate(title(), docs);
+        } catch (Exception e) {
+            log.error(e, "Failed to generate config help for {}", id());
+            return "";
+        }
+    }
+}

--- a/azertio-core/src/main/java/org/azertio/core/help/StepHelpAdapter.java
+++ b/azertio-core/src/main/java/org/azertio/core/help/StepHelpAdapter.java
@@ -1,0 +1,49 @@
+package org.azertio.core.help;
+
+import org.azertio.core.contributors.HelpProvider;
+import org.azertio.core.docgen.StepDocLoader;
+import org.azertio.core.docgen.StepDocMarkdownGenerator;
+import org.azertio.core.util.Log;
+
+import java.io.InputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public abstract class StepHelpAdapter implements HelpProvider {
+
+    private static final Log log = Log.of();
+
+    @Override
+    public String help() {
+        return generateHelp();
+    }
+
+    protected abstract String resource();
+
+    protected abstract Map<String, String> languageResources();
+
+    protected abstract String title();
+
+    private String generateHelp() {
+        try {
+            var mod = getClass().getModule();
+            var mainStream = mod.getResourceAsStream(resource());
+            if (mainStream == null) {
+                log.warn("[help] resource not found in module {}: {}", mod.getName(), resource());
+                return "";
+            }
+            var langStreams = new LinkedHashMap<String, InputStream>();
+            for (var entry : languageResources().entrySet()) {
+                var stream = mod.getResourceAsStream(entry.getValue());
+                if (stream != null) langStreams.put(entry.getKey(), stream);
+            }
+            var docs = langStreams.isEmpty()
+                ? StepDocLoader.load(mainStream)
+                : StepDocLoader.load(mainStream, langStreams);
+            return new StepDocMarkdownGenerator().generate(title(), docs);
+        } catch (Exception e) {
+            log.error(e, "Failed to generate step help for {}", id());
+            return "";
+        }
+    }
+}

--- a/azertio-core/src/main/java/org/azertio/core/help/StepHelpAdapter.java
+++ b/azertio-core/src/main/java/org/azertio/core/help/StepHelpAdapter.java
@@ -13,36 +13,44 @@ public abstract class StepHelpAdapter implements HelpProvider {
 
     private static final Log log = Log.of();
 
-    @Override
-    public String help() {
-        return generateHelp();
+    private final String id;
+    private final String displayName;
+    private final String title;
+    private final String resource;
+    private final Map<String, String> languageResources;
+
+    protected StepHelpAdapter(String id, String displayName, String title,
+                               String resource, Map<String, String> languageResources) {
+        this.id = id;
+        this.displayName = displayName;
+        this.title = title;
+        this.resource = resource;
+        this.languageResources = languageResources;
     }
 
-    protected abstract String resource();
+    @Override public String id()          { return id; }
+    @Override public String displayName() { return displayName; }
 
-    protected abstract Map<String, String> languageResources();
-
-    protected abstract String title();
-
-    private String generateHelp() {
+    @Override
+    public String help() {
         try {
             var mod = getClass().getModule();
-            var mainStream = mod.getResourceAsStream(resource());
+            var mainStream = mod.getResourceAsStream(resource);
             if (mainStream == null) {
-                log.warn("[help] resource not found in module {}: {}", mod.getName(), resource());
+                log.warn("[help] resource not found in module {}: {}", mod.getName(), resource);
                 return "";
             }
             var langStreams = new LinkedHashMap<String, InputStream>();
-            for (var entry : languageResources().entrySet()) {
+            for (var entry : languageResources.entrySet()) {
                 var stream = mod.getResourceAsStream(entry.getValue());
                 if (stream != null) langStreams.put(entry.getKey(), stream);
             }
             var docs = langStreams.isEmpty()
                 ? StepDocLoader.load(mainStream)
                 : StepDocLoader.load(mainStream, langStreams);
-            return new StepDocMarkdownGenerator().generate(title(), docs);
+            return new StepDocMarkdownGenerator().generate(title, docs);
         } catch (Exception e) {
-            log.error(e, "Failed to generate step help for {}", id());
+            log.error(e, "Failed to generate step help for {}", id);
             return "";
         }
     }

--- a/azertio-core/src/main/java/org/azertio/core/steps/CoreConfigHelpProvider.java
+++ b/azertio-core/src/main/java/org/azertio/core/steps/CoreConfigHelpProvider.java
@@ -1,0 +1,19 @@
+package org.azertio.core.steps;
+
+import org.myjtools.jexten.Extension;
+import org.myjtools.jexten.Scope;
+import org.azertio.core.contributors.HelpProvider;
+import org.azertio.core.help.ConfigHelpAdapter;
+
+@Extension(scope = Scope.SINGLETON)
+public class CoreConfigHelpProvider extends ConfigHelpAdapter implements HelpProvider {
+
+    @Override public String id()          { return "core.config"; }
+    @Override public String displayName() { return "Core Configuration"; }
+    @Override protected String title()    { return "Core Configuration"; }
+
+    @Override
+    protected String resource() {
+        return "core-config.yaml";
+    }
+}

--- a/azertio-core/src/main/java/org/azertio/core/steps/CoreConfigHelpProvider.java
+++ b/azertio-core/src/main/java/org/azertio/core/steps/CoreConfigHelpProvider.java
@@ -8,12 +8,7 @@ import org.azertio.core.help.ConfigHelpAdapter;
 @Extension(scope = Scope.SINGLETON)
 public class CoreConfigHelpProvider extends ConfigHelpAdapter implements HelpProvider {
 
-    @Override public String id()          { return "core.config"; }
-    @Override public String displayName() { return "Core Configuration"; }
-    @Override protected String title()    { return "Core Configuration"; }
-
-    @Override
-    protected String resource() {
-        return "core-config.yaml";
+    public CoreConfigHelpProvider() {
+        super("core.config", "Core Configuration", "Core Configuration", "core-config.yaml");
     }
 }

--- a/azertio-core/src/main/java/org/azertio/core/steps/CoreStepHelpProvider.java
+++ b/azertio-core/src/main/java/org/azertio/core/steps/CoreStepHelpProvider.java
@@ -1,0 +1,30 @@
+package org.azertio.core.steps;
+
+import org.myjtools.jexten.Extension;
+import org.myjtools.jexten.Scope;
+import org.azertio.core.contributors.HelpProvider;
+import org.azertio.core.help.StepHelpAdapter;
+
+import java.util.Map;
+
+@Extension(scope = Scope.SINGLETON)
+public class CoreStepHelpProvider extends StepHelpAdapter implements HelpProvider {
+
+    @Override public String id()          { return "core.steps"; }
+    @Override public String displayName() { return "Core Steps"; }
+    @Override protected String title()    { return "Core Steps"; }
+
+    @Override
+    protected String resource() {
+        return "core-steps.yaml";
+    }
+
+    @Override
+    protected Map<String, String> languageResources() {
+        return Map.of(
+            "dsl", "core-steps_dsl.yaml",
+            "en",  "core-steps_en.yaml",
+            "es",  "core-steps_es.yaml"
+        );
+    }
+}

--- a/azertio-core/src/main/java/org/azertio/core/steps/CoreStepHelpProvider.java
+++ b/azertio-core/src/main/java/org/azertio/core/steps/CoreStepHelpProvider.java
@@ -10,21 +10,11 @@ import java.util.Map;
 @Extension(scope = Scope.SINGLETON)
 public class CoreStepHelpProvider extends StepHelpAdapter implements HelpProvider {
 
-    @Override public String id()          { return "core.steps"; }
-    @Override public String displayName() { return "Core Steps"; }
-    @Override protected String title()    { return "Core Steps"; }
-
-    @Override
-    protected String resource() {
-        return "core-steps.yaml";
-    }
-
-    @Override
-    protected Map<String, String> languageResources() {
-        return Map.of(
+    public CoreStepHelpProvider() {
+        super("core.steps", "Core Steps", "Core Steps", "core-steps.yaml", Map.of(
             "dsl", "core-steps_dsl.yaml",
             "en",  "core-steps_en.yaml",
             "es",  "core-steps_es.yaml"
-        );
+        ));
     }
 }

--- a/azertio-core/src/test/java/module-info.java
+++ b/azertio-core/src/test/java/module-info.java
@@ -19,6 +19,7 @@ module org.azertio.core.test {
 	opens org.azertio.core.test.datatypes to org.junit.platform.commons;
 	opens org.azertio.core.test.expressions to org.junit.platform.commons;
 	opens org.azertio.core.test.docgen to org.junit.platform.commons;
+	opens org.azertio.core.test.help to org.junit.platform.commons;
 	opens org.azertio.core.test.messages to org.junit.platform.commons;
 	opens org.azertio.core.test.execution to org.junit.platform.commons;
 	opens org.azertio.core.test.contenttypes to org.junit.platform.commons;

--- a/azertio-core/src/test/java/org/azertio/core/test/docgen/ConfigDocMarkdownGeneratorTest.java
+++ b/azertio-core/src/test/java/org/azertio/core/test/docgen/ConfigDocMarkdownGeneratorTest.java
@@ -1,0 +1,136 @@
+package org.azertio.core.test.docgen;
+
+import org.junit.jupiter.api.Test;
+import org.azertio.core.docgen.ConfigDocEntry;
+import org.azertio.core.docgen.ConfigDocMarkdownGenerator;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfigDocMarkdownGeneratorTest {
+
+    private final ConfigDocMarkdownGenerator generator = new ConfigDocMarkdownGenerator();
+
+    private static ConfigDocEntry entry(String description, String type, boolean required,
+                                        Object defaultValue, String pattern,
+                                        Number min, Number max, List<String> values) {
+        return new ConfigDocEntry(description, type, required, defaultValue, pattern, min, max, values);
+    }
+
+    @Test
+    void generate_emptyEntries_returnsOnlyTitle() {
+        String result = generator.generate("My Config", Map.of());
+        assertThat(result).startsWith("# My Config\n\n");
+    }
+
+    @Test
+    void generate_entryWithType_includesSeparatorKeyAndType() {
+        var e = entry(null, "text", false, null, null, null, null, null);
+        String result = generator.generate("Config", Map.of("my.key", e));
+        assertThat(result).contains("---\n\n## `my.key`\n\n");
+        assertThat(result).contains("**Type** text\n\n");
+    }
+
+    @Test
+    void generate_entryWithDescription_includesDescription() {
+        var e = entry("A description", "text", false, null, null, null, null, null);
+        String result = generator.generate("Config", Map.of("k", e));
+        assertThat(result).contains("A description\n\n");
+    }
+
+    @Test
+    void generate_entryWithBlankDescription_omitsDescription() {
+        var e = entry("   ", "text", false, null, null, null, null, null);
+        String result = generator.generate("Config", Map.of("k", e));
+        assertThat(result).doesNotContain("   \n\n");
+    }
+
+    @Test
+    void generate_entryRequired_includesRequiredMarker() {
+        var e = entry(null, "text", true, null, null, null, null, null);
+        String result = generator.generate("Config", Map.of("k", e));
+        assertThat(result).contains("**Required**\n\n");
+    }
+
+    @Test
+    void generate_entryNotRequired_omitsRequiredMarker() {
+        var e = entry(null, "text", false, null, null, null, null, null);
+        String result = generator.generate("Config", Map.of("k", e));
+        assertThat(result).doesNotContain("**Required**");
+    }
+
+    @Test
+    void generate_entryWithDefaultValue_includesDefaultValue() {
+        var e = entry(null, "integer", false, 42, null, null, null, null);
+        String result = generator.generate("Config", Map.of("k", e));
+        assertThat(result).contains("**Default value** `42`\n\n");
+    }
+
+    @Test
+    void generate_entryWithNullDefaultValue_omitsDefaultValue() {
+        var e = entry(null, "text", false, null, null, null, null, null);
+        String result = generator.generate("Config", Map.of("k", e));
+        assertThat(result).doesNotContain("**Default value**");
+    }
+
+    @Test
+    void generate_entryWithPattern_includesPattern() {
+        var e = entry(null, "text", false, null, "A\\d\\dB", null, null, null);
+        String result = generator.generate("Config", Map.of("k", e));
+        assertThat(result).contains("**Pattern** `A\\d\\dB`\n\n");
+    }
+
+    @Test
+    void generate_entryWithMinOnly_includesMin() {
+        var e = entry(null, "integer", false, null, null, 2, null, null);
+        String result = generator.generate("Config", Map.of("k", e));
+        assertThat(result).contains("**Min** `2`");
+        assertThat(result).doesNotContain("**Max**");
+    }
+
+    @Test
+    void generate_entryWithMaxOnly_includesMax() {
+        var e = entry(null, "integer", false, null, null, null, 10, null);
+        String result = generator.generate("Config", Map.of("k", e));
+        assertThat(result).contains("**Max** `10`");
+        assertThat(result).doesNotContain("**Min**");
+    }
+
+    @Test
+    void generate_entryWithMinAndMax_includesBoth() {
+        var e = entry(null, "integer", false, null, null, 1, 5, null);
+        String result = generator.generate("Config", Map.of("k", e));
+        assertThat(result).contains("**Min** `1`");
+        assertThat(result).contains("**Max** `5`");
+    }
+
+    @Test
+    void generate_entryWithConstraintValues_includesValuesList() {
+        var e = entry(null, "enum", false, null, null, null, null, List.of("red", "green", "blue"));
+        String result = generator.generate("Config", Map.of("k", e));
+        assertThat(result).contains("**Values**");
+        assertThat(result).contains("`red`");
+        assertThat(result).contains("`green`");
+        assertThat(result).contains("`blue`");
+    }
+
+    @Test
+    void generate_entryWithEmptyConstraintValues_omitsValuesSection() {
+        var e = entry(null, "text", false, null, null, null, null, List.of());
+        String result = generator.generate("Config", Map.of("k", e));
+        assertThat(result).doesNotContain("**Values**");
+    }
+
+    @Test
+    void generate_multipleEntries_allPresent() {
+        var entries = new LinkedHashMap<String, ConfigDocEntry>();
+        entries.put("key.one", entry(null, "text", false, null, null, null, null, null));
+        entries.put("key.two", entry(null, "integer", true, 0, null, null, null, null));
+        String result = generator.generate("Config", entries);
+        assertThat(result).contains("## `key.one`");
+        assertThat(result).contains("## `key.two`");
+    }
+}

--- a/azertio-core/src/test/java/org/azertio/core/test/docgen/StepDocMarkdownGeneratorTest.java
+++ b/azertio-core/src/test/java/org/azertio/core/test/docgen/StepDocMarkdownGeneratorTest.java
@@ -1,0 +1,144 @@
+package org.azertio.core.test.docgen;
+
+import org.junit.jupiter.api.Test;
+import org.azertio.core.docgen.ParameterDoc;
+import org.azertio.core.docgen.ScenarioExample;
+import org.azertio.core.docgen.StepDocEntry;
+import org.azertio.core.docgen.StepDocMarkdownGenerator;
+import org.azertio.core.docgen.StepLanguageEntry;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StepDocMarkdownGeneratorTest {
+
+    private final StepDocMarkdownGenerator generator = new StepDocMarkdownGenerator();
+
+    @Test
+    void generate_emptySteps_returnsOnlyTitle() {
+        String result = generator.generate("My Title", Map.of());
+        assertThat(result).startsWith("# My Title\n\n");
+        assertThat(result.trim()).isEqualTo("# My Title");
+    }
+
+    @Test
+    void generate_stepWithDescription_includesSeparatorAndId() {
+        var step = new StepDocEntry(null, "A description", List.of(), null, Map.of());
+        String result = generator.generate("Steps", Map.of("my.step", step));
+        assertThat(result).contains("---\n\n## `my.step`\n\n");
+        assertThat(result).contains("A description\n\n");
+    }
+
+    @Test
+    void generate_stepWithRole_includesRoleLine() {
+        var step = new StepDocEntry("action", "desc", List.of(), null, Map.of());
+        String result = generator.generate("Steps", Map.of("s", step));
+        assertThat(result).contains("**Role:** `action`\n\n");
+    }
+
+    @Test
+    void generate_stepWithoutRole_omitsRoleLine() {
+        var step = new StepDocEntry(null, "desc", List.of(), null, Map.of());
+        String result = generator.generate("Steps", Map.of("s", step));
+        assertThat(result).doesNotContain("**Role:**");
+    }
+
+    @Test
+    void generate_stepWithParameters_includesParameterTable() {
+        var params = List.of(
+            new ParameterDoc("url", "text", "The target URL"),
+            new ParameterDoc("timeout", "integer", "Max wait time")
+        );
+        var step = new StepDocEntry(null, "desc", params, null, Map.of());
+        String result = generator.generate("Steps", Map.of("s", step));
+        assertThat(result).contains("### Parameters\n\n");
+        assertThat(result).contains("| Name | Type | Description |");
+        assertThat(result).contains("| `url` | text | The target URL |");
+        assertThat(result).contains("| `timeout` | integer | Max wait time |");
+    }
+
+    @Test
+    void generate_stepWithEmptyParameters_omitsParameterSection() {
+        var step = new StepDocEntry(null, "desc", List.of(), null, Map.of());
+        String result = generator.generate("Steps", Map.of("s", step));
+        assertThat(result).doesNotContain("### Parameters");
+    }
+
+    @Test
+    void generate_stepWithAdditionalData_includesSection() {
+        var step = new StepDocEntry(null, "desc", List.of(), "Extra info here", Map.of());
+        String result = generator.generate("Steps", Map.of("s", step));
+        assertThat(result).contains("### Additional data\n\n");
+        assertThat(result).contains("Extra info here\n\n");
+    }
+
+    @Test
+    void generate_stepWithNullAdditionalData_omitsSection() {
+        var step = new StepDocEntry(null, "desc", List.of(), null, Map.of());
+        String result = generator.generate("Steps", Map.of("s", step));
+        assertThat(result).doesNotContain("### Additional data");
+    }
+
+    @Test
+    void generate_languageEntryWithExpression_includesExpression() {
+        var lang = new StepLanguageEntry("I do {x:text}", null, List.of(), List.of());
+        var step = new StepDocEntry(null, "desc", List.of(), null, Map.of("en", lang));
+        String result = generator.generate("Steps", Map.of("s", step));
+        assertThat(result).contains("### `en`\n\n");
+        assertThat(result).contains("**Expression:** `I do {x:text}`\n\n");
+    }
+
+    @Test
+    void generate_languageEntryWithoutExpression_omitsExpressionLine() {
+        var lang = new StepLanguageEntry(null, null, List.of(), List.of());
+        var step = new StepDocEntry(null, "desc", List.of(), null, Map.of("en", lang));
+        String result = generator.generate("Steps", Map.of("s", step));
+        assertThat(result).doesNotContain("**Expression:**");
+    }
+
+    @Test
+    void generate_languageEntryWithAssertionHints_includesBullets() {
+        var lang = new StepLanguageEntry(null, null, List.of(), List.of("hint A", "hint B"));
+        var step = new StepDocEntry(null, "desc", List.of(), null, Map.of("en", lang));
+        String result = generator.generate("Steps", Map.of("s", step));
+        assertThat(result).contains("**Assertion expressions:**\n\n");
+        assertThat(result).contains("- `hint A`\n");
+        assertThat(result).contains("- `hint B`\n");
+    }
+
+    @Test
+    void generate_languageEntryWithExample_includesGherkinBlock() {
+        var lang = new StepLanguageEntry(null, "Given I do something", List.of(), List.of());
+        var step = new StepDocEntry(null, "desc", List.of(), null, Map.of("en", lang));
+        String result = generator.generate("Steps", Map.of("s", step));
+        assertThat(result).contains("**Example:**\n\n```gherkin\nGiven I do something\n```\n\n");
+    }
+
+    @Test
+    void generate_languageEntryWithScenarios_includesAllScenarios() {
+        var scenarios = List.of(
+            new ScenarioExample("Happy path", "Given A\nWhen B\nThen C"),
+            new ScenarioExample(null, "Given X\nThen Y")
+        );
+        var lang = new StepLanguageEntry(null, null, scenarios, List.of());
+        var step = new StepDocEntry(null, "desc", List.of(), null, Map.of("en", lang));
+        String result = generator.generate("Steps", Map.of("s", step));
+        assertThat(result).contains("**Scenarios:**\n\n");
+        assertThat(result).contains("*Happy path*\n\n");
+        assertThat(result).contains("```gherkin\nGiven A\nWhen B\nThen C\n```\n\n");
+        assertThat(result).contains("```gherkin\nGiven X\nThen Y\n```\n\n");
+    }
+
+    @Test
+    void generate_multipleSteps_allStepsPresent() {
+        var steps = new LinkedHashMap<String, StepDocEntry>();
+        steps.put("step.one", new StepDocEntry(null, "First", List.of(), null, Map.of()));
+        steps.put("step.two", new StepDocEntry(null, "Second", List.of(), null, Map.of()));
+        String result = generator.generate("Steps", steps);
+        assertThat(result).contains("## `step.one`");
+        assertThat(result).contains("## `step.two`");
+    }
+}

--- a/azertio-core/src/test/java/org/azertio/core/test/help/ConfigHelpAdapterTest.java
+++ b/azertio-core/src/test/java/org/azertio/core/test/help/ConfigHelpAdapterTest.java
@@ -7,27 +7,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ConfigHelpAdapterTest {
 
+    static class TestConfigAdapter extends ConfigHelpAdapter {
+        TestConfigAdapter(String resource) {
+            super("test.id", "Test", "Test Config", resource);
+        }
+    }
+
     @Test
     void help_whenResourceNotFound_returnsEmpty() {
-        var adapter = new ConfigHelpAdapter() {
-            @Override public String id() { return "test"; }
-            @Override public String displayName() { return "Test"; }
-            @Override protected String resource() { return "nonexistent-resource.yaml"; }
-            @Override protected String title() { return "Test"; }
-        };
-        assertThat(adapter.help()).isEmpty();
+        assertThat(new TestConfigAdapter("nonexistent-resource.yaml").help()).isEmpty();
     }
 
     @Test
     void help_whenResourceFound_returnsMarkdownWithTitle() {
-        var adapter = new ConfigHelpAdapter() {
-            @Override public String id() { return "test"; }
-            @Override public String displayName() { return "Test"; }
-            @Override protected String resource() { return "config.yaml"; }
-            @Override protected String title() { return "Test Configuration"; }
-        };
-        String result = adapter.help();
+        String result = new TestConfigAdapter("config.yaml").help();
         assertThat(result).isNotEmpty();
-        assertThat(result).startsWith("# Test Configuration");
+        assertThat(result).startsWith("# Test Config");
     }
 }

--- a/azertio-core/src/test/java/org/azertio/core/test/help/ConfigHelpAdapterTest.java
+++ b/azertio-core/src/test/java/org/azertio/core/test/help/ConfigHelpAdapterTest.java
@@ -1,0 +1,33 @@
+package org.azertio.core.test.help;
+
+import org.junit.jupiter.api.Test;
+import org.azertio.core.help.ConfigHelpAdapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfigHelpAdapterTest {
+
+    @Test
+    void help_whenResourceNotFound_returnsEmpty() {
+        var adapter = new ConfigHelpAdapter() {
+            @Override public String id() { return "test"; }
+            @Override public String displayName() { return "Test"; }
+            @Override protected String resource() { return "nonexistent-resource.yaml"; }
+            @Override protected String title() { return "Test"; }
+        };
+        assertThat(adapter.help()).isEmpty();
+    }
+
+    @Test
+    void help_whenResourceFound_returnsMarkdownWithTitle() {
+        var adapter = new ConfigHelpAdapter() {
+            @Override public String id() { return "test"; }
+            @Override public String displayName() { return "Test"; }
+            @Override protected String resource() { return "config.yaml"; }
+            @Override protected String title() { return "Test Configuration"; }
+        };
+        String result = adapter.help();
+        assertThat(result).isNotEmpty();
+        assertThat(result).startsWith("# Test Configuration");
+    }
+}

--- a/azertio-core/src/test/java/org/azertio/core/test/help/StepHelpAdapterTest.java
+++ b/azertio-core/src/test/java/org/azertio/core/test/help/StepHelpAdapterTest.java
@@ -9,29 +9,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class StepHelpAdapterTest {
 
+    static class TestStepAdapter extends StepHelpAdapter {
+        TestStepAdapter(String resource) {
+            super("test.id", "Test", "Test Title", resource, Map.of());
+        }
+    }
+
     @Test
     void help_whenResourceNotFound_returnsEmpty() {
-        var adapter = new StepHelpAdapter() {
-            @Override public String id() { return "test"; }
-            @Override public String displayName() { return "Test"; }
-            @Override protected String resource() { return "nonexistent-resource.yaml"; }
-            @Override protected String title() { return "Test"; }
-            @Override protected Map<String, String> languageResources() { return Map.of(); }
-        };
-        assertThat(adapter.help()).isEmpty();
+        assertThat(new TestStepAdapter("nonexistent-resource.yaml").help()).isEmpty();
     }
 
     @Test
     void help_whenResourceFound_returnsMarkdownWithTitle() {
-        var adapter = new StepHelpAdapter() {
-            @Override public String id() { return "test"; }
-            @Override public String displayName() { return "Test"; }
-            @Override protected String resource() { return "step-doc.yaml"; }
-            @Override protected String title() { return "Test Steps"; }
-            @Override protected Map<String, String> languageResources() { return Map.of(); }
-        };
-        String result = adapter.help();
+        String result = new TestStepAdapter("step-doc.yaml").help();
         assertThat(result).isNotEmpty();
-        assertThat(result).startsWith("# Test Steps");
+        assertThat(result).startsWith("# Test Title");
     }
 }

--- a/azertio-core/src/test/java/org/azertio/core/test/help/StepHelpAdapterTest.java
+++ b/azertio-core/src/test/java/org/azertio/core/test/help/StepHelpAdapterTest.java
@@ -1,0 +1,37 @@
+package org.azertio.core.test.help;
+
+import org.junit.jupiter.api.Test;
+import org.azertio.core.help.StepHelpAdapter;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StepHelpAdapterTest {
+
+    @Test
+    void help_whenResourceNotFound_returnsEmpty() {
+        var adapter = new StepHelpAdapter() {
+            @Override public String id() { return "test"; }
+            @Override public String displayName() { return "Test"; }
+            @Override protected String resource() { return "nonexistent-resource.yaml"; }
+            @Override protected String title() { return "Test"; }
+            @Override protected Map<String, String> languageResources() { return Map.of(); }
+        };
+        assertThat(adapter.help()).isEmpty();
+    }
+
+    @Test
+    void help_whenResourceFound_returnsMarkdownWithTitle() {
+        var adapter = new StepHelpAdapter() {
+            @Override public String id() { return "test"; }
+            @Override public String displayName() { return "Test"; }
+            @Override protected String resource() { return "step-doc.yaml"; }
+            @Override protected String title() { return "Test Steps"; }
+            @Override protected Map<String, String> languageResources() { return Map.of(); }
+        };
+        String result = adapter.help();
+        assertThat(result).isNotEmpty();
+        assertThat(result).startsWith("# Test Steps");
+    }
+}

--- a/azertio-jsonrpc/src/main/java/org/azertio/jsonrpc/serve/JsonRpcServer.java
+++ b/azertio-jsonrpc/src/main/java/org/azertio/jsonrpc/serve/JsonRpcServer.java
@@ -13,6 +13,7 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
@@ -40,6 +41,12 @@ public class JsonRpcServer {
     @FunctionalInterface
     public interface StepIndexProvider {
         String getIndex();
+    }
+
+    public interface HelpRegistryProvider {
+        record Entry(String id, String displayName) {}
+        List<Entry> list();
+        Optional<String> content(String id);
     }
 
     @FunctionalInterface
@@ -80,6 +87,7 @@ public class JsonRpcServer {
     private final PlanHandler planHandler;
     private final ContributorsProvider contributorsProvider;
     private final StepIndexProvider stepIndexProvider;
+    private final HelpRegistryProvider helpRegistryProvider;
     private TestPlanRepository repository;
     private TestExecutionRepository executionRepository;
     private AttachmentRepository attachmentRepository;
@@ -102,6 +110,10 @@ public class JsonRpcServer {
     }
 
     public JsonRpcServer(InputStream in, OutputStream out, RepositoryFactory factory, ExecHandler execHandler, PlanHandler planHandler, ContributorsProvider contributorsProvider, StepIndexProvider stepIndexProvider) {
+        this(in, out, factory, execHandler, planHandler, contributorsProvider, stepIndexProvider, null);
+    }
+
+    public JsonRpcServer(InputStream in, OutputStream out, RepositoryFactory factory, ExecHandler execHandler, PlanHandler planHandler, ContributorsProvider contributorsProvider, StepIndexProvider stepIndexProvider, HelpRegistryProvider helpRegistryProvider) {
         this.in = in;
         this.out = out;
         this.factory = factory;
@@ -109,6 +121,7 @@ public class JsonRpcServer {
         this.planHandler = planHandler;
         this.contributorsProvider = contributorsProvider;
         this.stepIndexProvider = stepIndexProvider;
+        this.helpRegistryProvider = helpRegistryProvider;
     }
 
     public void run() {
@@ -197,6 +210,8 @@ public class JsonRpcServer {
                 case "executions/delete" -> { handleDeleteExecution(params); yield JsonNull.INSTANCE; }
                 case "contributors/list" -> handleContributors();
                 case "steps/index"       -> handleStepsIndex();
+                case "help/list"         -> handleHelpList();
+                case "help/get"          -> handleHelpGet(params);
                 case "exec"                   -> handleExec(params);
                 case "refresh"         -> { handleRefresh(); yield JsonNull.INSTANCE; }
                 case "shutdown"        -> { running = false; yield JsonNull.INSTANCE; }
@@ -512,6 +527,31 @@ public class JsonRpcServer {
         if (stepIndexProvider == null)
             throw new IllegalStateException("Step index provider not configured");
         return JsonParser.parseString(stepIndexProvider.getIndex());
+    }
+
+    private JsonArray handleHelpList() {
+        if (helpRegistryProvider == null)
+            throw new IllegalStateException("Help registry provider not configured");
+        JsonArray arr = new JsonArray();
+        for (var entry : helpRegistryProvider.list()) {
+            JsonObject obj = new JsonObject();
+            obj.addProperty("id", entry.id());
+            obj.addProperty("displayName", entry.displayName());
+            arr.add(obj);
+        }
+        return arr;
+    }
+
+    private JsonObject handleHelpGet(JsonObject params) {
+        if (helpRegistryProvider == null)
+            throw new IllegalStateException("Help registry provider not configured");
+        String id = params.get("id").getAsString();
+        String content = helpRegistryProvider.content(id)
+            .orElseThrow(() -> new IllegalArgumentException("Help provider not found: " + id));
+        JsonObject obj = new JsonObject();
+        obj.addProperty("id", id);
+        obj.addProperty("content", content);
+        return obj;
     }
 
     private void handleDeleteExecution(JsonObject params) {

--- a/azertio-jsonrpc/src/test/java/org/azertio/jsonrpc/serve/test/JsonRpcServerTest.java
+++ b/azertio-jsonrpc/src/test/java/org/azertio/jsonrpc/serve/test/JsonRpcServerTest.java
@@ -1195,4 +1195,91 @@ class JsonRpcServerTest {
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getAsJsonObject().get("id").getAsString()).isEqualTo("my.step");
     }
+
+    @Test
+    void helpListWithoutProviderReturnsError() {
+        List<JsonObject> responses = run(
+            () -> new StubPlanRepo() {},
+            req(1, "help/list", "{}"),
+            req(99, "shutdown", "{}")
+        );
+        assertThat(responses.get(0).has("error")).isTrue();
+    }
+
+    @Test
+    void helpListReturnsEntries() {
+        JsonRpcServer.HelpRegistryProvider provider = new JsonRpcServer.HelpRegistryProvider() {
+            @Override public List<JsonRpcServer.HelpRegistryProvider.Entry> list() {
+                return List.of(
+                    new JsonRpcServer.HelpRegistryProvider.Entry("core.steps", "Core Steps"),
+                    new JsonRpcServer.HelpRegistryProvider.Entry("db.steps", "DB Steps")
+                );
+            }
+            @Override public Optional<String> content(String id) { return Optional.empty(); }
+        };
+
+        byte[][] frames = {frame(req(1, "help/list", "{}")), frame(req(99, "shutdown", "{}"))};
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new JsonRpcServer(
+            new ByteArrayInputStream(concat(frames)), out,
+            () -> new StubPlanRepo() {},
+            null, null, null, null, provider
+        ).run();
+
+        var arr = parseResponses(out.toByteArray()).get(0).getAsJsonArray("result");
+        assertThat(arr).hasSize(2);
+        assertThat(arr.get(0).getAsJsonObject().get("id").getAsString()).isEqualTo("core.steps");
+        assertThat(arr.get(0).getAsJsonObject().get("displayName").getAsString()).isEqualTo("Core Steps");
+        assertThat(arr.get(1).getAsJsonObject().get("id").getAsString()).isEqualTo("db.steps");
+    }
+
+    @Test
+    void helpGetWithoutProviderReturnsError() {
+        List<JsonObject> responses = run(
+            () -> new StubPlanRepo() {},
+            req(1, "help/get", "{\"id\":\"core.steps\"}"),
+            req(99, "shutdown", "{}")
+        );
+        assertThat(responses.get(0).has("error")).isTrue();
+    }
+
+    @Test
+    void helpGetReturnsContent() {
+        JsonRpcServer.HelpRegistryProvider provider = new JsonRpcServer.HelpRegistryProvider() {
+            @Override public List<JsonRpcServer.HelpRegistryProvider.Entry> list() { return List.of(); }
+            @Override public Optional<String> content(String id) {
+                return id.equals("core.steps") ? Optional.of("# Core Steps\n\nContent here") : Optional.empty();
+            }
+        };
+
+        byte[][] frames = {frame(req(1, "help/get", "{\"id\":\"core.steps\"}")), frame(req(99, "shutdown", "{}"))};
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new JsonRpcServer(
+            new ByteArrayInputStream(concat(frames)), out,
+            () -> new StubPlanRepo() {},
+            null, null, null, null, provider
+        ).run();
+
+        var result = parseResponses(out.toByteArray()).get(0).getAsJsonObject("result");
+        assertThat(result.get("id").getAsString()).isEqualTo("core.steps");
+        assertThat(result.get("content").getAsString()).isEqualTo("# Core Steps\n\nContent here");
+    }
+
+    @Test
+    void helpGetNotFoundReturnsError() {
+        JsonRpcServer.HelpRegistryProvider provider = new JsonRpcServer.HelpRegistryProvider() {
+            @Override public List<JsonRpcServer.HelpRegistryProvider.Entry> list() { return List.of(); }
+            @Override public Optional<String> content(String id) { return Optional.empty(); }
+        };
+
+        byte[][] frames = {frame(req(1, "help/get", "{\"id\":\"unknown\"}")), frame(req(99, "shutdown", "{}"))};
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new JsonRpcServer(
+            new ByteArrayInputStream(concat(frames)), out,
+            () -> new StubPlanRepo() {},
+            null, null, null, null, provider
+        ).run();
+
+        assertThat(parseResponses(out.toByteArray()).get(0).has("error")).isTrue();
+    }
 }

--- a/azertio-vscode/package.json
+++ b/azertio-vscode/package.json
@@ -95,6 +95,15 @@
       {
         "command": "azertio.ai.toggle",
         "title": "Azertio: Toggle AI Completions"
+      },
+      {
+        "command": "azertio.help.open",
+        "title": "Azertio: Open Help Page"
+      },
+      {
+        "command": "azertio.help.refresh",
+        "title": "Azertio: Refresh Help",
+        "icon": "$(refresh)"
       }
     ],
     "viewsContainers": {
@@ -122,6 +131,11 @@
           "id": "azertio.contributors",
           "name": "Contributors",
           "icon": "$(extensions)"
+        },
+        {
+          "id": "azertio.help",
+          "name": "Help",
+          "icon": "$(book)"
         }
       ]
     },
@@ -145,6 +159,11 @@
         {
           "command": "azertio.contributors.refresh",
           "when": "view == azertio.contributors",
+          "group": "navigation"
+        },
+        {
+          "command": "azertio.help.refresh",
+          "when": "view == azertio.help",
           "group": "navigation"
         }
       ],

--- a/azertio-vscode/src/azertioClient.ts
+++ b/azertio-vscode/src/azertioClient.ts
@@ -96,6 +96,16 @@ export interface PluginContributors {
     contributors: ContributorTypeInfo[];
 }
 
+export interface HelpEntry {
+    id: string;
+    displayName: string;
+}
+
+export interface HelpContent {
+    id: string;
+    content: string;
+}
+
 type PendingRequest = {
     resolve: (result: unknown) => void;
     reject: (err: Error) => void;
@@ -164,6 +174,14 @@ export class AzertioClient {
     async getStepsIndex(): Promise<string> {
         const result = await this.call('steps/index', {});
         return JSON.stringify(result);
+    }
+
+    async listHelp(): Promise<HelpEntry[]> {
+        return this.call('help/list', {}) as Promise<HelpEntry[]>;
+    }
+
+    async getHelp(id: string): Promise<HelpContent> {
+        return this.call('help/get', { id }) as Promise<HelpContent>;
     }
 
     async listPlans(): Promise<PlanInfo[]> {

--- a/azertio-vscode/src/extension.ts
+++ b/azertio-vscode/src/extension.ts
@@ -9,6 +9,7 @@ import { ExecutionProvider } from './executionProvider';
 import { openExecutionDetail } from './executionDetailPanel';
 import { ISSUE_URI_SCHEME, TestPlanProvider } from './testPlanProvider';
 import { ContributorsProvider } from './contributorsProvider';
+import { HelpProvider as HelpTreeProvider, HelpDocumentProvider, HELP_URI_SCHEME } from './helpProvider';
 import { AiCompletionProvider } from './aiCompletionProvider';
 import {
     CloseAction,
@@ -252,6 +253,14 @@ export function activate(context: vscode.ExtensionContext): void {
     const contributorsProvider = new ContributorsProvider(logOutput);
     vscode.window.registerTreeDataProvider('azertio.contributors', contributorsProvider);
 
+    const helpTreeProvider = new HelpTreeProvider(logOutput);
+    vscode.window.registerTreeDataProvider('azertio.help', helpTreeProvider);
+
+    const helpDocumentProvider = new HelpDocumentProvider();
+    context.subscriptions.push(
+        vscode.workspace.registerTextDocumentContentProvider(HELP_URI_SCHEME, helpDocumentProvider)
+    );
+
     // Auto-populate the tree on startup using existing plan data (no plan re-run).
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
 
@@ -265,6 +274,9 @@ export function activate(context: vscode.ExtensionContext): void {
             logOutput('[startup] starting serve connection');
             serveClient = new AzertioClient(executable, workspaceFolder.uri.fsPath, logOutput);
             contributorsProvider.setClient(serveClient);
+            helpTreeProvider.setClient(serveClient);
+            helpDocumentProvider.setClient(serveClient);
+            serveClient.onConnected = () => { helpTreeProvider.refresh(); };
             serveClient.connect();
             testPlanProvider.setClient(serveClient);
             testPlanProvider.invalidate();
@@ -321,6 +333,9 @@ export function activate(context: vscode.ExtensionContext): void {
         logOutput(`[build] starting new serve connection`);
         serveClient = new AzertioClient(executable, cwd, logOutput);
         contributorsProvider.setClient(serveClient);
+        helpTreeProvider.setClient(serveClient);
+        helpDocumentProvider.setClient(serveClient);
+        serveClient.onConnected = () => { helpTreeProvider.refresh(); };
         serveClient.connect();
         testPlanProvider.setClient(serveClient);
         executionProvider.setClient(serveClient);
@@ -518,6 +533,22 @@ export function activate(context: vscode.ExtensionContext): void {
                 const msg = err instanceof Error ? err.message : String(err);
                 vscode.window.showErrorMessage(`Azertio: failed to delete plan — ${msg}`);
             }
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('azertio.help.open', async (id: string) => {
+            await helpDocumentProvider.fetchAndCache(id);
+            await vscode.commands.executeCommand(
+                'markdown.showPreview',
+                HelpDocumentProvider.uriFor(id)
+            );
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('azertio.help.refresh', async () => {
+            await helpTreeProvider.refresh();
         })
     );
 

--- a/azertio-vscode/src/helpProvider.ts
+++ b/azertio-vscode/src/helpProvider.ts
@@ -1,0 +1,86 @@
+import * as vscode from 'vscode';
+import { AzertioClient, HelpEntry } from './azertioClient';
+
+export const HELP_URI_SCHEME = 'azertio-help';
+
+export class HelpItem extends vscode.TreeItem {
+    constructor(public readonly entry: HelpEntry) {
+        super(entry.displayName, vscode.TreeItemCollapsibleState.None);
+        this.iconPath = new vscode.ThemeIcon('book');
+        this.contextValue = 'helpEntry';
+        this.command = {
+            command: 'azertio.help.open',
+            title: 'Open Help',
+            arguments: [entry.id],
+        };
+    }
+}
+
+export class HelpProvider implements vscode.TreeDataProvider<HelpItem> {
+
+    private readonly _onDidChangeTreeData = new vscode.EventEmitter<HelpItem | undefined | void>();
+    readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+    private client: AzertioClient | undefined;
+    private entries: HelpEntry[] = [];
+
+    constructor(private readonly log: (msg: string) => void = () => {}) {}
+
+    setClient(client: AzertioClient): void {
+        this.client = client;
+    }
+
+    async refresh(): Promise<void> {
+        if (!this.client) { return; }
+        try {
+            this.entries = await this.client.listHelp();
+        } catch (err) {
+            this.log(`[help] failed to load list: ${err}`);
+            this.entries = [];
+        }
+        this._onDidChangeTreeData.fire();
+    }
+
+    getTreeItem(element: HelpItem): vscode.TreeItem {
+        return element;
+    }
+
+    getChildren(element?: HelpItem): HelpItem[] {
+        if (element) { return []; }
+        return this.entries.map(e => new HelpItem(e));
+    }
+}
+
+/**
+ * Provides read-only Markdown content fetched via `help/get` for the virtual
+ * URI scheme `azertio-help:<id>`. VSCode's built-in Markdown preview renders it.
+ */
+export class HelpDocumentProvider implements vscode.TextDocumentContentProvider {
+
+    private readonly cache = new Map<string, string>();
+    private client: AzertioClient | undefined;
+
+    setClient(client: AzertioClient): void {
+        this.client = client;
+        this.cache.clear();
+    }
+
+    async fetchAndCache(id: string): Promise<void> {
+        if (!this.client) { return; }
+        try {
+            const result = await this.client.getHelp(id);
+            this.cache.set(id, result.content);
+        } catch {
+            this.cache.set(id, `# Error\n\nCould not load help for \`${id}\`.`);
+        }
+    }
+
+    provideTextDocumentContent(uri: vscode.Uri): string {
+        const id = uri.path.startsWith('/') ? uri.path.slice(1) : uri.path;
+        return this.cache.get(id) ?? '';
+    }
+
+    static uriFor(id: string): vscode.Uri {
+        return vscode.Uri.from({ scheme: HELP_URI_SCHEME, path: `/${id}` });
+    }
+}

--- a/examples/test-plan/azertio.yaml
+++ b/examples/test-plan/azertio.yaml
@@ -17,9 +17,9 @@ project:
         tag-expression: DB
 
 plugins:
-    - gherkin
-    - rest
-    - "db with com.mysql:mysql-connector-j"
+    - org.azertio.plugins:gherkin-azertio-plugin:1.0.0-alpha2-SNAPSHOT
+    - org.azertio.plugins:rest-azertio-plugin:1.0.0-alpha2-SNAPSHOT
+    - "org.azertio.plugins:db-azertio-plugin:1.0.0-alpha2-SNAPSHOT with com.mysql:mysql-connector-j"
 
 configuration:
     core:

--- a/plugins/db-azertio-plugin/src/main/java/module-info.java
+++ b/plugins/db-azertio-plugin/src/main/java/module-info.java
@@ -1,6 +1,8 @@
 import org.azertio.plugins.db.DbAIIndexProvider;
+import org.azertio.plugins.db.DbConfigHelpProvider;
 import org.azertio.plugins.db.DbConfigProvider;
 import org.azertio.plugins.db.DbMessageProvider;
+import org.azertio.plugins.db.DbStepHelpProvider;
 import org.azertio.plugins.db.DbStepProvider;
 
 module org.azertio.plugins.db {
@@ -18,6 +20,7 @@ requires org.apache.poi.ooxml;
 	provides org.azertio.core.contributors.ConfigProvider with DbConfigProvider;
 	provides org.azertio.core.messages.MessageProvider with DbMessageProvider;
 	provides org.azertio.core.contributors.AIIndexProvider with DbAIIndexProvider;
+	provides org.azertio.core.contributors.HelpProvider with DbStepHelpProvider, DbConfigHelpProvider;
 
 	exports org.azertio.plugins.db;
 	opens org.azertio.plugins.db to org.myjtools.jexten;

--- a/plugins/db-azertio-plugin/src/main/java/org/azertio/plugins/db/DbConfigHelpProvider.java
+++ b/plugins/db-azertio-plugin/src/main/java/org/azertio/plugins/db/DbConfigHelpProvider.java
@@ -1,0 +1,19 @@
+package org.azertio.plugins.db;
+
+import org.myjtools.jexten.Extension;
+import org.myjtools.jexten.Scope;
+import org.azertio.core.contributors.HelpProvider;
+import org.azertio.core.help.ConfigHelpAdapter;
+
+@Extension(scope = Scope.SINGLETON)
+public class DbConfigHelpProvider extends ConfigHelpAdapter implements HelpProvider {
+
+    @Override public String id()          { return "db.config"; }
+    @Override public String displayName() { return "Database Configuration"; }
+    @Override protected String title()    { return "Database Configuration"; }
+
+    @Override
+    protected String resource() {
+        return "config.yaml";
+    }
+}

--- a/plugins/db-azertio-plugin/src/main/java/org/azertio/plugins/db/DbConfigHelpProvider.java
+++ b/plugins/db-azertio-plugin/src/main/java/org/azertio/plugins/db/DbConfigHelpProvider.java
@@ -8,12 +8,7 @@ import org.azertio.core.help.ConfigHelpAdapter;
 @Extension(scope = Scope.SINGLETON)
 public class DbConfigHelpProvider extends ConfigHelpAdapter implements HelpProvider {
 
-    @Override public String id()          { return "db.config"; }
-    @Override public String displayName() { return "Database Configuration"; }
-    @Override protected String title()    { return "Database Configuration"; }
-
-    @Override
-    protected String resource() {
-        return "config.yaml";
+    public DbConfigHelpProvider() {
+        super("db.config", "Database Configuration", "Database Configuration", "config.yaml");
     }
 }

--- a/plugins/db-azertio-plugin/src/main/java/org/azertio/plugins/db/DbStepHelpProvider.java
+++ b/plugins/db-azertio-plugin/src/main/java/org/azertio/plugins/db/DbStepHelpProvider.java
@@ -10,21 +10,11 @@ import java.util.Map;
 @Extension(scope = Scope.SINGLETON)
 public class DbStepHelpProvider extends StepHelpAdapter implements HelpProvider {
 
-    @Override public String id()          { return "db.steps"; }
-    @Override public String displayName() { return "Database Steps"; }
-    @Override protected String title()    { return "Database Steps"; }
-
-    @Override
-    protected String resource() {
-        return "steps.yaml";
-    }
-
-    @Override
-    protected Map<String, String> languageResources() {
-        return Map.of(
+    public DbStepHelpProvider() {
+        super("db.steps", "Database Steps", "Database Steps", "steps.yaml", Map.of(
             "dsl", "steps_dsl.yaml",
             "en",  "steps_en.yaml",
             "es",  "steps_es.yaml"
-        );
+        ));
     }
 }

--- a/plugins/db-azertio-plugin/src/main/java/org/azertio/plugins/db/DbStepHelpProvider.java
+++ b/plugins/db-azertio-plugin/src/main/java/org/azertio/plugins/db/DbStepHelpProvider.java
@@ -1,0 +1,30 @@
+package org.azertio.plugins.db;
+
+import org.myjtools.jexten.Extension;
+import org.myjtools.jexten.Scope;
+import org.azertio.core.contributors.HelpProvider;
+import org.azertio.core.help.StepHelpAdapter;
+
+import java.util.Map;
+
+@Extension(scope = Scope.SINGLETON)
+public class DbStepHelpProvider extends StepHelpAdapter implements HelpProvider {
+
+    @Override public String id()          { return "db.steps"; }
+    @Override public String displayName() { return "Database Steps"; }
+    @Override protected String title()    { return "Database Steps"; }
+
+    @Override
+    protected String resource() {
+        return "steps.yaml";
+    }
+
+    @Override
+    protected Map<String, String> languageResources() {
+        return Map.of(
+            "dsl", "steps_dsl.yaml",
+            "en",  "steps_en.yaml",
+            "es",  "steps_es.yaml"
+        );
+    }
+}

--- a/plugins/rest-azertio-plugin/src/main/java/module-info.java
+++ b/plugins/rest-azertio-plugin/src/main/java/module-info.java
@@ -1,6 +1,8 @@
 import org.azertio.plugins.rest.RestAIIndexProvider;
+import org.azertio.plugins.rest.RestConfigHelpProvider;
 import org.azertio.plugins.rest.RestConfigProvider;
 import org.azertio.plugins.rest.RestMessageProvider;
+import org.azertio.plugins.rest.RestStepHelpProvider;
 import org.azertio.plugins.rest.RestStepProvider;
 
 module org.azertio.plugins.rest {
@@ -14,6 +16,7 @@ module org.azertio.plugins.rest {
     provides org.azertio.core.contributors.ConfigProvider with RestConfigProvider;
     provides org.azertio.core.messages.MessageProvider with RestMessageProvider;
     provides org.azertio.core.contributors.AIIndexProvider with RestAIIndexProvider;
+    provides org.azertio.core.contributors.HelpProvider with RestStepHelpProvider, RestConfigHelpProvider;
 
     exports org.azertio.plugins.rest;
     opens org.azertio.plugins.rest to org.myjtools.jexten;

--- a/plugins/rest-azertio-plugin/src/main/java/org/azertio/plugins/rest/RestConfigHelpProvider.java
+++ b/plugins/rest-azertio-plugin/src/main/java/org/azertio/plugins/rest/RestConfigHelpProvider.java
@@ -8,12 +8,7 @@ import org.azertio.core.help.ConfigHelpAdapter;
 @Extension(scope = Scope.SINGLETON)
 public class RestConfigHelpProvider extends ConfigHelpAdapter implements HelpProvider {
 
-    @Override public String id()          { return "rest.config"; }
-    @Override public String displayName() { return "REST Configuration"; }
-    @Override protected String title()    { return "REST Configuration"; }
-
-    @Override
-    protected String resource() {
-        return "config.yaml";
+    public RestConfigHelpProvider() {
+        super("rest.config", "REST Configuration", "REST Configuration", "config.yaml");
     }
 }

--- a/plugins/rest-azertio-plugin/src/main/java/org/azertio/plugins/rest/RestConfigHelpProvider.java
+++ b/plugins/rest-azertio-plugin/src/main/java/org/azertio/plugins/rest/RestConfigHelpProvider.java
@@ -1,0 +1,19 @@
+package org.azertio.plugins.rest;
+
+import org.myjtools.jexten.Extension;
+import org.myjtools.jexten.Scope;
+import org.azertio.core.contributors.HelpProvider;
+import org.azertio.core.help.ConfigHelpAdapter;
+
+@Extension(scope = Scope.SINGLETON)
+public class RestConfigHelpProvider extends ConfigHelpAdapter implements HelpProvider {
+
+    @Override public String id()          { return "rest.config"; }
+    @Override public String displayName() { return "REST Configuration"; }
+    @Override protected String title()    { return "REST Configuration"; }
+
+    @Override
+    protected String resource() {
+        return "config.yaml";
+    }
+}

--- a/plugins/rest-azertio-plugin/src/main/java/org/azertio/plugins/rest/RestStepHelpProvider.java
+++ b/plugins/rest-azertio-plugin/src/main/java/org/azertio/plugins/rest/RestStepHelpProvider.java
@@ -1,0 +1,30 @@
+package org.azertio.plugins.rest;
+
+import org.myjtools.jexten.Extension;
+import org.myjtools.jexten.Scope;
+import org.azertio.core.contributors.HelpProvider;
+import org.azertio.core.help.StepHelpAdapter;
+
+import java.util.Map;
+
+@Extension(scope = Scope.SINGLETON)
+public class RestStepHelpProvider extends StepHelpAdapter implements HelpProvider {
+
+    @Override public String id()          { return "rest.steps"; }
+    @Override public String displayName() { return "REST Steps"; }
+    @Override protected String title()    { return "REST Steps"; }
+
+    @Override
+    protected String resource() {
+        return "steps.yaml";
+    }
+
+    @Override
+    protected Map<String, String> languageResources() {
+        return Map.of(
+            "dsl", "steps_dsl.yaml",
+            "en",  "steps_en.yaml",
+            "es",  "steps_es.yaml"
+        );
+    }
+}

--- a/plugins/rest-azertio-plugin/src/main/java/org/azertio/plugins/rest/RestStepHelpProvider.java
+++ b/plugins/rest-azertio-plugin/src/main/java/org/azertio/plugins/rest/RestStepHelpProvider.java
@@ -10,21 +10,11 @@ import java.util.Map;
 @Extension(scope = Scope.SINGLETON)
 public class RestStepHelpProvider extends StepHelpAdapter implements HelpProvider {
 
-    @Override public String id()          { return "rest.steps"; }
-    @Override public String displayName() { return "REST Steps"; }
-    @Override protected String title()    { return "REST Steps"; }
-
-    @Override
-    protected String resource() {
-        return "steps.yaml";
-    }
-
-    @Override
-    protected Map<String, String> languageResources() {
-        return Map.of(
+    public RestStepHelpProvider() {
+        super("rest.steps", "REST Steps", "REST Steps", "steps.yaml", Map.of(
             "dsl", "steps_dsl.yaml",
             "en",  "steps_en.yaml",
             "es",  "steps_es.yaml"
-        );
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- Introduces `HelpProvider` SPI so core and plugins can expose markdown help content (steps and config)
- Adds JSON-RPC endpoints `help/list` and `help/get`, wired through `ServeCommand` and `JsonRpcServer`
- Adds a VS Code **Help** tree view panel that fetches entries on connect and renders pages via the built-in markdown preview

## Test plan

- [ ] Build core + plugins and verify `HelpProvider` implementations are discovered via jexten
- [ ] Run `azertio serve` and call `help/list` via JSON-RPC to confirm all providers are listed
- [ ] Call `help/get` with a valid id and confirm markdown content is returned
- [ ] Open VS Code extension, connect to a workspace and verify the Help panel populates
- [ ] Click a help entry and confirm it opens the markdown preview correctly
- [ ] Test `azertio.help.refresh` command refreshes the tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)