### PR TITLE
Release azertio core v1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.4] - 2026-07-04
+
+### Fixed
+- LSP: `*` (the universal Gherkin step keyword) was not recognized for step completion when the file's locale has no dedicated keyword resource — affects Azertio's `dsl` compact shorthand, where `*` is the only step marker. Step-body completions in VS Code never triggered for these files.
+
+### Dependencies
+- `commons-configuration2` 2.15.0 → 2.15.1
+- `junit-jupiter` 5.11.4 → 5.14.4
+- `maven-plugin-annotations` 3.15.1 → 3.15.2
+- `commonmark-ext-gfm-tables` 0.24.0 → 0.29.0
+- `jackson-databind` 2.18.8 → 2.22.0
+- `okhttp-jvm` 5.1.0 → 5.4.0
+
+
 ## [1.2.3] - 2026-06-29
 
 ### Fixed

--- a/azertio-cli/pom.xml
+++ b/azertio-cli/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.azertio</groupId>
         <artifactId>azertio</artifactId>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>1.2.4</version>
     </parent>
 
     <artifactId>azertio-cli</artifactId>

--- a/azertio-cli/src/main/java/org/azertio/cli/VersionCommand.java
+++ b/azertio-cli/src/main/java/org/azertio/cli/VersionCommand.java
@@ -8,7 +8,7 @@ import picocli.CommandLine;
 )
 public class VersionCommand extends AbstractCommand {
 
-	public static final String VERSION = "1.2.3";
+	public static final String VERSION = "1.2.4";
 
 	@Override
 	public void execute() {

--- a/azertio-core/pom.xml
+++ b/azertio-core/pom.xml
@@ -7,7 +7,7 @@
 	 <parent>
 		 <groupId>org.azertio</groupId>
 		 <artifactId>azertio</artifactId>
-		 <version>1.3.0-SNAPSHOT</version>
+		 <version>1.2.4</version>
 		 <relativePath>../pom.xml</relativePath>
 	 </parent>
 

--- a/azertio-docgen-maven-plugin/pom.xml
+++ b/azertio-docgen-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.azertio</groupId>
         <artifactId>azertio</artifactId>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>1.2.4</version>
     </parent>
 
     <artifactId>azertio-docgen-maven-plugin</artifactId>

--- a/azertio-it/pom.xml
+++ b/azertio-it/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.azertio</groupId>
         <artifactId>azertio</artifactId>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>1.2.4</version>
     </parent>
 
     <artifactId>azertio-it</artifactId>

--- a/azertio-jsonrpc/pom.xml
+++ b/azertio-jsonrpc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.azertio</groupId>
         <artifactId>azertio</artifactId>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>1.2.4</version>
     </parent>
 
     <artifactId>azertio-jsonrpc</artifactId>

--- a/azertio-lsp/pom.xml
+++ b/azertio-lsp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.azertio</groupId>
         <artifactId>azertio</artifactId>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>1.2.4</version>
     </parent>
 
     <artifactId>azertio-lsp</artifactId>

--- a/azertio-lsp/src/main/java/org/azertio/lsp/AzertioTextDocumentService.java
+++ b/azertio-lsp/src/main/java/org/azertio/lsp/AzertioTextDocumentService.java
@@ -26,10 +26,14 @@ public class AzertioTextDocumentService implements TextDocumentService {
     private static final List<KeywordType> STEP_KEYWORD_TYPES = List.of(
         KeywordType.GIVEN, KeywordType.WHEN, KeywordType.THEN, KeywordType.AND, KeywordType.BUT
     );
-    private static final List<String> DEFAULT_STEP_KEYWORDS  = List.of("Given", "When", "Then", "And", "But");
+    // '*' is included because it is a universal step keyword valid in every Gherkin dialect
+    // (see gherkin_en.properties / gherkin_es.properties: "given=*,Given,...") — it must be
+    // recognized even when the locale has no dedicated keyword resource, e.g. Azertio's "dsl"
+    // pseudo-locale, which uses '*' exclusively.
+    private static final List<String> DEFAULT_STEP_KEYWORDS  = List.of("Given", "When", "Then", "And", "But", "*");
     private static final List<String> DEFAULT_GHERKIN_KEYWORDS = List.of(
         "Feature:", "Background:", "Scenario:", "Scenario Outline:",
-        "Examples:", "Given ", "When ", "Then ", "And ", "But "
+        "Examples:", "Given ", "When ", "Then ", "And ", "But ", "* "
     );
 
     // ─── azertio.yaml schema (static) ─────────────────────────────────────────

--- a/azertio-persistence/pom.xml
+++ b/azertio-persistence/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.azertio</groupId>
 		<artifactId>azertio</artifactId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.2.4</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/azertio-plugin-starter/pom.xml
+++ b/azertio-plugin-starter/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.azertio</groupId>
     <artifactId>azertio-plugin-starter</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.2.4</version>
     <packaging>pom</packaging>
 
     <name>Azertio Plugin Starter</name>
@@ -53,8 +53,8 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <java.version>21</java.version>
-        <azertio-core.version>1.3.0-SNAPSHOT</azertio-core.version>
-        <azertio-docgen.version>1.3.0-SNAPSHOT</azertio-docgen.version>
+        <azertio-core.version>1.2.4</azertio-core.version>
+        <azertio-docgen.version>1.2.4</azertio-docgen.version>
         <jexten.version>1.0.1</jexten.version>
         <sonar.coverage.jacoco.xmlReportPaths>
             ${project.basedir}/target/site/jacoco/jacoco.xml

--- a/azertio-test-support/pom.xml
+++ b/azertio-test-support/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.azertio</groupId>
         <artifactId>azertio</artifactId>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>1.2.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/webui/azertio.yaml
+++ b/examples/webui/azertio.yaml
@@ -1,5 +1,6 @@
 project:
     name: Web UI Examples
+    organization: Azertio
     description: |
       Browser automation examples using the webui-azertio-plugin against the-internet.herokuapp.com,
       a stable public site maintained for UI testing practice.

--- a/plugins/db-azertio-plugin/pom.xml
+++ b/plugins/db-azertio-plugin/pom.xml
@@ -8,7 +8,7 @@
         <groupId>org.azertio</groupId>
         <artifactId>azertio-plugin-starter</artifactId>
 		<relativePath>../../azertio-plugin-starter/pom.xml</relativePath>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>1.2.4</version>
     </parent>
 
 
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.azertio</groupId>
             <artifactId>azertio-persistence</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>1.2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.azertio</groupId>
             <artifactId>azertio-test-support</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>1.2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/plugins/gherkin-azertio-plugin/pom.xml
+++ b/plugins/gherkin-azertio-plugin/pom.xml
@@ -8,7 +8,7 @@
 		<groupId>org.azertio</groupId>
 		<artifactId>azertio-plugin-starter</artifactId>
 		<relativePath>../../azertio-plugin-starter/pom.xml</relativePath>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.2.4</version>
 	</parent>
 
 
@@ -55,7 +55,7 @@
 		<dependency>
 			<groupId>org.azertio</groupId>
 			<artifactId>azertio-persistence</artifactId>
-			<version>1.3.0-SNAPSHOT</version>
+			<version>1.2.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/plugins/htmlreport-azertio-plugin/pom.xml
+++ b/plugins/htmlreport-azertio-plugin/pom.xml
@@ -8,7 +8,7 @@
         <groupId>org.azertio</groupId>
         <artifactId>azertio-plugin-starter</artifactId>
         <relativePath>../../azertio-plugin-starter/pom.xml</relativePath>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>1.2.4</version>
     </parent>
 
     <groupId>org.azertio.plugins</groupId>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.azertio</groupId>
             <artifactId>azertio-persistence</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>1.2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/plugins/markdown-plan-azertio-plugin/pom.xml
+++ b/plugins/markdown-plan-azertio-plugin/pom.xml
@@ -8,7 +8,7 @@
         <groupId>org.azertio</groupId>
         <artifactId>azertio-plugin-starter</artifactId>
 		<relativePath>../../azertio-plugin-starter/pom.xml</relativePath>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>1.2.4</version>
     </parent>
 
 
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.azertio</groupId>
             <artifactId>azertio-persistence</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>1.2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/plugins/pdfreport-azertio-plugin/pom.xml
+++ b/plugins/pdfreport-azertio-plugin/pom.xml
@@ -8,7 +8,7 @@
         <groupId>org.azertio</groupId>
         <artifactId>azertio-plugin-starter</artifactId>
         <relativePath>../../azertio-plugin-starter/pom.xml</relativePath>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>1.2.4</version>
     </parent>
 
     <groupId>org.azertio.plugins</groupId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.azertio</groupId>
             <artifactId>azertio-persistence</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>1.2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/plugins/rest-azertio-plugin/pom.xml
+++ b/plugins/rest-azertio-plugin/pom.xml
@@ -8,7 +8,7 @@
         <groupId>org.azertio</groupId>
         <artifactId>azertio-plugin-starter</artifactId>
 		<relativePath>../../azertio-plugin-starter/pom.xml</relativePath>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>1.2.4</version>
     </parent>
 
 
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.azertio</groupId>
             <artifactId>azertio-persistence</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>1.2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.azertio</groupId>
             <artifactId>azertio-test-support</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>1.2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/plugins/webui-azertio-plugin/pom.xml
+++ b/plugins/webui-azertio-plugin/pom.xml
@@ -8,7 +8,7 @@
         <groupId>org.azertio</groupId>
         <artifactId>azertio-plugin-starter</artifactId>
         <relativePath>../../azertio-plugin-starter/pom.xml</relativePath>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>1.2.4</version>
     </parent>
 
     <groupId>org.azertio.plugins</groupId>
@@ -19,7 +19,7 @@
     <description>A plugin that provides web UI browser automation steps</description>
 
     <properties>
-        <azertio-core.version>1.3.0-SNAPSHOT</azertio-core.version>
+        <azertio-core.version>1.2.4</azertio-core.version>
         <gherkin.version>1.0.1</gherkin.version>
         <azertio.docgen.stepDocFile>${project.basedir}/src/main/resources/steps.yaml</azertio.docgen.stepDocFile>
         <azertio.docgen.configFile>${project.basedir}/src/main/resources/config.yaml</azertio.docgen.configFile>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>org.azertio</groupId>
 	<artifactId>azertio</artifactId>
-	<version>1.3.0-SNAPSHOT</version>
+	<version>1.2.4</version>
 	<packaging>pom</packaging>
 
 	<name>Azertio</name>

--- a/www/index.html
+++ b/www/index.html
@@ -984,7 +984,7 @@
 
   <div class="hero-badge">
     <svg width="8" height="8" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#00ffe0"/></svg>
-    Open Source &nbsp;<span>· MIT License · v1.2.3</span>
+    Open Source &nbsp;<span>· MIT License · v1.2.4</span>
   </div>
 
   <h1>
@@ -1064,9 +1064,9 @@
           <div>
             <h3>Download &amp; install</h3>
             <p>Download the distribution ZIP, unzip it anywhere and add the <code>bin/</code> directory to your PATH.</p>
-            <a href="https://github.com/org-azertio/azertio/releases/download/v1.2.3/azertio-cli-1.2.3-dist.zip"
+            <a href="https://github.com/org-azertio/azertio/releases/download/v1.2.4/azertio-cli-1.2.4-dist.zip"
                class="btn-primary" style="display:inline-flex;margin-top:0.5rem;font-size:0.875rem;padding:0.6rem 1.4rem">
-              Download v1.2.3
+              Download v1.2.4
             </a>
           </div>
         </div>
@@ -1075,10 +1075,10 @@
             <div class="dot dot-r"></div><div class="dot dot-y"></div><div class="dot dot-g"></div>
             <span class="code-filename">shell</span>
           </div>
-          <pre><span class="t-prompt">$</span> unzip azertio-cli-1.2.3-dist.zip
-<span class="t-prompt">$</span> export PATH=<span class="str">"$PATH:$(pwd)/azertio-cli-1.2.3/bin"</span>
+          <pre><span class="t-prompt">$</span> unzip azertio-cli-1.2.4-dist.zip
+<span class="t-prompt">$</span> export PATH=<span class="str">"$PATH:$(pwd)/azertio-cli-1.2.4/bin"</span>
 <span class="t-prompt">$</span> azertio version
-<span class="t-pass">azertio 1.2.3</span></pre>
+<span class="t-pass">azertio 1.2.4</span></pre>
         </div>
       </div>
 


### PR DESCRIPTION
Sync main with the v1.2.4 core release.

- fix(lsp): recognize '*' as a step keyword when locale has no keyword resource
- build(release): azertio core 1.2.4

Tag `v1.2.4`, Maven Central deployment already published.